### PR TITLE
Fix .gitignore and docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Config files
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,9 @@ services:
     # - Build image from github directly
     #build: http://github.com/automuteus/galactus.git
 
-    ports:
-      # Only uncomment if you plan on developing other integrations, and want galactus exposed outside the docker network!
-      #- ${GALACTUS_PORT:-5858}:${GALACTUS_PORT:-5858}
+    # Only uncomment if you plan on developing other integrations, and want galactus exposed outside the docker network!
+    #ports:
+    #  - ${GALACTUS_PORT:-5858}:${GALACTUS_PORT:-5858}
     restart: always
     environment:
       # Required


### PR DESCRIPTION
Two small fixes:

* Add `.env` to `.gitignore`
* Comment out the `services.galactus.ports` that caused error in `docker-compose.yml`

If there are any problems, please feel free to reject this PR, thanks :)
