### PR TITLE
Update DockerHub tags URL

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,9 +1,9 @@
 # Please refer to the latest versions of Galactus and AutoMuteUs when specifying these versions:
 # Automuteus: https://github.com/automuteus/automuteus/releases
-# or https://hub.docker.com/repository/docker/denverquane/amongusdiscord/tags?page=1&ordering=last_updated
+# or https://hub.docker.com/r/automuteus/automuteus/tags
 
 # Galactus: https://github.com/automuteus/galactus/releases
-# or https://hub.docker.com/repository/docker/automuteus/galactus/tags?page=1&ordering=last_updated
+# or https://hub.docker.com/r/automuteus/galactus/tags
 
 AUTOMUTEUS_TAG=
 GALACTUS_TAG=


### PR DESCRIPTION
`https://hub.docker.com/repository/...` URL requires login with DockerHub, but `https://hub.docker.com/r/`URL does not require login, so we should use `/r/` URL.