### PR TITLE
fix: remove unused ports from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,6 @@ services:
     #build: https://github.com/automuteus/automuteus.git
 
     restart: always
-    ports:
-      # 5000 is the default service port
-      # Format is HostPort:ContainerPort
-      - ${SERVICE_PORT:-5000}:5000
     environment:
       # These are required and will fail if not present
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:?err}
@@ -43,11 +39,19 @@ services:
       - postgres
     volumes:
       - "bot-logs:/app/logs"
+
   galactus:
+    # Either:
+    # - Use a prebuilt image
+    image: automuteus/galactus:${GALACTUS_TAG:?err}
+    # - Build image from local source
+    #build: ../galactus
+    # - Build image from github directly
+    #build: https://github.com/automuteus/galactus.git
+
     ports:
       # See sample.env for details, but in general, match the GALACTUS_EXTERNAL_PORT w/ the GALACTUS_HOST's port
       - ${GALACTUS_EXTERNAL_PORT:-8123}:${BROKER_PORT}
-    image: automuteus/galactus:${GALACTUS_TAG:?err}
     restart: always
     environment:
       # This Variable is optional


### PR DESCRIPTION
Unused `ports` (`5000:5000`) was ported from v6 repository.

This PR removes that unused port settings, and add a bit comments for devs.